### PR TITLE
Bump to a node 12 compatible version of node-expat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm t
+      - store_artifacts:
+          path: coverage/lcov-report
+          destination: coverage

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-machine:
-  node:
-    version: 8
-test:
-  post:
-    - mv coverage/lcov-report $CIRCLE_ARTIFACTS/coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmler",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "repository": {
@@ -10,7 +10,7 @@
   "author": "Ziggy Jonsson (ziggy.jonsson.nyc@gmail.com)",
   "license": "MIT",
   "dependencies": {
-    "node-expat": "~2.3.17"
+    "node-expat": "sutoiku/node-expat#a27cdc5"
   },
   "devDependencies": {
     "tap": "^12.0.1",


### PR DESCRIPTION
* bump to a node 12 compatible version of nodepexpat
* Switch to circleci 2.0

Temporarily using https://github.com/sutoiku/node-expat until https://github.com/astro/node-expat/pull/196 is merged